### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_auth_backend_amqp_sup.erl
+++ b/src/rabbit_auth_backend_amqp_sup.erl
@@ -31,4 +31,4 @@ init([]) ->
     {ok, {{one_for_one,3,10},
           [{rabbit_auth_backend_amqp,
             {rabbit_auth_backend_amqp, start_link, []},
-            transient, ?MAX_WAIT, worker, [rabbit_auth_backend_amqp]}]}}.
+            transient, ?WORKER_WAIT, worker, [rabbit_auth_backend_amqp]}]}}.


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` 