### PR TITLE
Support topic authorisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ authentication server framework based around the
 implementation in `com.rabbitmq.authbackend.examples` (which will
 authenticate "simon" / "simon"). This implementation also checks
 the routing key starts by `a` when publishing to a topic exchange
-(a.k.a topic authorisation TODO add link to topic authorisation).
+(a.k.a. [topic authorisation](http://www.rabbitmq.com/access-control.html#topic-authorisation)).

--- a/README.md
+++ b/README.md
@@ -83,4 +83,6 @@ In `examples/rabbitmq-auth-backend-java` there's a Java based
 authentication server framework based around the
 `com.rabbitmq.authbackend.AuthBackend` interface with a very trivial
 implementation in `com.rabbitmq.authbackend.examples` (which will
-authenticate "simon" / "simon").
+authenticate "simon" / "simon"). This implementation also checks
+the routing key starts by `a` when publishing to a topic exchange
+(a.k.a topic authorisation TODO add link to topic authorisation).

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Or, in the classic config format (`rabbitmq.config`, prior to 3.7.0) or `advance
     ].
 
 Authentication requests will be packed into the headers of incoming
-messages. There are three types of request: `login`, `check_vhost` and
-`check_resource`. Responses should be returned in the message
+messages. There are four types of request: `login`, `check_vhost`,
+`check_resource` and `check_topic`. Responses should be returned in the message
 body. Responses to `login` requests should be "refused" if login is
 unsuccessful or a comma-separated list of tags for the user if login
 is successful. Responses to the other types should be the words

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthBackend.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthBackend.java
@@ -16,6 +16,12 @@ public interface AuthBackend {
                           String vhost,
                           String resourceName,
                           ResourceType resourceType,
+                          ResourcePermission permission);
+
+    boolean checkTopic(String username,
+                          String vhost,
+                          String resourceName,
+                          ResourceType resourceType,
                           ResourcePermission permission,
                           String routingKey);
 }

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthBackend.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthBackend.java
@@ -16,5 +16,6 @@ public interface AuthBackend {
                           String vhost,
                           String resourceName,
                           ResourceType resourceType,
-                          ResourcePermission permission);
+                          ResourcePermission permission,
+                          String routingKey);
 }

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthServer.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthServer.java
@@ -45,8 +45,16 @@ public class AuthServer extends RpcServer {
                     get("vhost", headers),
                     get("name", headers),
                     ResourceType.valueOf(getU("resource", headers)),
-                    ResourcePermission.valueOf(getU("permission", headers)),
-                    get("routing_key", headers)));
+                    ResourcePermission.valueOf(getU("permission", headers))));
+        }
+        else if (action.equals("check_topic")) {
+            return bool(authBackend.checkTopic(
+                get("username", headers),
+                get("vhost", headers),
+                get("name", headers),
+                ResourceType.valueOf(getU("resource", headers)),
+                ResourcePermission.valueOf(getU("permission", headers)),
+                get("routing_key", headers)));
         }
 
         throw new RuntimeException("Unexpected action " + action);

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthServer.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/AuthServer.java
@@ -45,7 +45,8 @@ public class AuthServer extends RpcServer {
                     get("vhost", headers),
                     get("name", headers),
                     ResourceType.valueOf(getU("resource", headers)),
-                    ResourcePermission.valueOf(getU("permission", headers))));
+                    ResourcePermission.valueOf(getU("permission", headers)),
+                    get("routing_key", headers)));
         }
 
         throw new RuntimeException("Unexpected action " + action);

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/ResourceType.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/ResourceType.java
@@ -1,5 +1,5 @@
 package com.rabbitmq.authbackend;
 
 public enum ResourceType {
-    EXCHANGE, QUEUE
+    EXCHANGE, QUEUE, TOPIC
 }

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/examples/ExampleAuthBackend.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/examples/ExampleAuthBackend.java
@@ -38,12 +38,16 @@ public class ExampleAuthBackend implements AuthBackend {
                                  String vhost,
                                  String resourceName,
                                  ResourceType resourceType,
-                                 ResourcePermission permission,
-                                 String routingKey) {
-        if(resourceType == ResourceType.TOPIC) {
-            return routingKey.startsWith("a");
-        } else {
-            return true;
-        }
+                                 ResourcePermission permission) {
+        return true;
+    }
+
+    public boolean checkTopic(String username,
+                              String vhost,
+                              String resourceName,
+                              ResourceType resourceType,
+                              ResourcePermission permission,
+                              String routingKey) {
+        return routingKey.startsWith("a");
     }
 }

--- a/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/examples/ExampleAuthBackend.java
+++ b/examples/rabbitmq-auth-backend-java/src/com/rabbitmq/authbackend/examples/ExampleAuthBackend.java
@@ -38,7 +38,12 @@ public class ExampleAuthBackend implements AuthBackend {
                                  String vhost,
                                  String resourceName,
                                  ResourceType resourceType,
-                                 ResourcePermission permission) {
-        return true;
+                                 ResourcePermission permission,
+                                 String routingKey) {
+        if(resourceType == ResourceType.TOPIC) {
+            return routingKey.startsWith("a");
+        } else {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Forward resource options as headers of the message sent to the
AMQP backend. This includes the routing key when publishing
to a topic exchange. Add a check against the routing key
in the Java sample backend.

Part of rabbitmq/rabbitmq-server#505