### PR TITLE
Shorter prefix for configuration keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Below is a minimal `rabbitmq.conf` example (currently only in master):
     auth_backends.1 = internal
     auth_backends.2 = amqp
 
-    rabbit_auth_backend_amqp.username = guest
-    rabbit_auth_backend_amqp.vhost    = /
-    rabbit_auth_backend_amqp.exchange = authentication
+    auth_amqp.username = guest
+    auth_amqp.vhost    = /
+    auth_amqp.exchange = authentication
 
 Or, in the classic config format (`rabbitmq.config`, prior to 3.7.0) or `advanced.config`:
 

--- a/priv/schema/rabbitmq_auth_backend_amqp.schema
+++ b/priv/schema/rabbitmq_auth_backend_amqp.schema
@@ -1,27 +1,27 @@
-{mapping, "rabbitmq_auth_backend_amqp.username", "rabbitmq_auth_backend_amqp.username", 
+{mapping, "auth_amqp.username", "rabbitmq_auth_backend_amqp.username",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_auth_backend_amqp.username",
 fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("rabbitmq_auth_backend_amqp.username", Conf))
+    list_to_binary(cuttlefish:conf_get("auth_amqp.username", Conf))
 end}.
 
-{mapping, "rabbitmq_auth_backend_amqp.vhost", "rabbitmq_auth_backend_amqp.vhost", 
+{mapping, "auth_amqp.vhost", "rabbitmq_auth_backend_amqp.vhost",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_auth_backend_amqp.vhost",
 fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("rabbitmq_auth_backend_amqp.vhost", Conf))
+    list_to_binary(cuttlefish:conf_get("auth_amqp.vhost", Conf))
 end}.
 
-{mapping, "rabbitmq_auth_backend_amqp.exchange", "rabbitmq_auth_backend_amqp.exchange", 
+{mapping, "auth_amqp.exchange", "rabbitmq_auth_backend_amqp.exchange",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_auth_backend_amqp.exchange",
 fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("rabbitmq_auth_backend_amqp.exchange", Conf))
+    list_to_binary(cuttlefish:conf_get("auth_amqp.exchange", Conf))
 end}.
 
 
-{mapping, "rabbitmq_auth_backend_amqp.timeout", "rabbitmq_auth_backend_amqp.timeout",
+{mapping, "auth_amqp.timeout", "rabbitmq_auth_backend_amqp.timeout",
     [{datatype, [{enum, [infinity]}, integer]}]}.


### PR DESCRIPTION
Follow-up to rabbitmq/rabbitmq-auth-backend-ldap#59