### PR TITLE
Handle map when building AMQP message headers

### DIFF
--- a/src/rabbit_auth_backend_amqp.erl
+++ b/src/rabbit_auth_backend_amqp.erl
@@ -32,6 +32,9 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 
+% for testing
+-export([table/1]).
+
 -define(SERVER, ?MODULE).
 -define(CHECK_RESOURCE_ACCESS_HEADERS, [username, vhost, resource, name, permission]).
 
@@ -238,8 +241,18 @@ incr(State = #state{correlation_id = Id}) ->
     State#state{correlation_id = Id + 1}.
 
 table(Query) ->
-    [table_row(Row) || Row <- Query].
+    lists:flatten([table_row(Row) || Row <- Query]).
 
+table_row({MapKey, Map}) when is_map(Map) ->
+    MapKeyBin = bin(MapKey),
+    Delimiter = <<".">>,
+    KeyPrefix = <<MapKeyBin/binary, Delimiter/binary>>,
+    [begin
+        KeyBin = rabbit_data_coercion:to_binary(Key),
+        KeyWithPrefix = <<KeyPrefix/binary, KeyBin/binary>>,
+        table_row({KeyWithPrefix,rabbit_data_coercion:to_binary(Value)})
+     end
+         || {Key, Value} <- maps:to_list(Map)];
 table_row({K, V}) ->
     {bin(K), longstr, bin(V)}.
 

--- a/src/rabbit_auth_backend_amqp.erl
+++ b/src/rabbit_auth_backend_amqp.erl
@@ -250,7 +250,7 @@ table_row({MapKey, Map}) when is_map(Map) ->
     [begin
         KeyBin = rabbit_data_coercion:to_binary(Key),
         KeyWithPrefix = <<KeyPrefix/binary, KeyBin/binary>>,
-        table_row({KeyWithPrefix,rabbit_data_coercion:to_binary(Value)})
+        table_row({KeyWithPrefix, rabbit_data_coercion:to_binary(Value)})
      end
          || {Key, Value} <- maps:to_list(Map)];
 table_row({K, V}) ->

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -1,0 +1,63 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(unit_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+        {non_parallel_tests, [], [
+            table
+        ]}
+    ].
+
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+
+table(_Config) ->
+    [{<<"action">>,longstr,<<"check_resource">>},
+     {<<"username">>,longstr,<<"simon">>},
+     {<<"vhost">>,longstr,<<"/">>},
+     {<<"resource">>,longstr,<<"queue">>},
+     {<<"name">>,longstr,<<"mqtt-subscription-01">>},
+     {<<"permission">>,longstr,<<"read">>}] = rabbit_auth_backend_amqp:table(
+        [{action,check_resource},
+         {username,<<"simon">>},
+         {vhost,<<"/">>},
+         {resource,queue},
+         {name,<<"mqtt-subscription-01">>},
+         {permission,read}]
+    ),
+
+    [{<<"action">>,longstr,<<"check_topic">>},
+     {<<"routing_key">>,longstr,<<"amq.topic">>},
+     {<<"variable_map.client_id">>,longstr,<<"TestPublisher">>},
+     {<<"variable_map.username">>,longstr,<<"simon">>},
+     {<<"variable_map.vhost">>,longstr,<<"/">>}] = rabbit_auth_backend_amqp:table(
+       [{action,check_topic},
+        {routing_key,<<"amq.topic">>},
+        {variable_map,#{<<"client_id">> => <<"TestPublisher">>,
+                        <<"username">> => <<"simon">>,
+                        <<"vhost">> => <<"/">>}}]),
+    ok.


### PR DESCRIPTION
An Erlang map is turned in to several headers. E.g.
{variable_map, #{username => guest, vhost = some-vhost}} is converted
into 2 headers: variable_map.username=guest and variable_map.vhost=some-vhost.

Fixes #16